### PR TITLE
Add Claude Code settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ pids
 
 # Optional eslint cache
 .eslintcache
+
+# Claude Code settings
+**/.claude/settings.local.json


### PR DESCRIPTION
## Summary

This PR adds Claude Code personal configuration files to `.gitignore` to prevent environment-specific settings from being committed to the repository.

## Changes

### 📁 .gitignore
Added exclusion pattern for Claude Code personal settings:
```
# Claude Code settings
**/.claude/settings.local.json
```

## Reasoning

**Why exclude `.claude/settings.local.json`?**
- Contains **personal environment configurations** (file permissions, allowed commands, etc.)
- **Environment-specific** - different for each developer's setup
- **Not meant to be shared** - can cause conflicts in team development
- **Security considerations** - may contain sensitive permission configurations

## Benefits

✅ **Prevents unintended commits** of personal Claude Code settings  
✅ **Reduces merge conflicts** in team development  
✅ **Improves repository hygiene** by excluding environment-specific files  
✅ **Follows best practices** for ignoring user-specific configuration files  

## Pattern Details

- **Pattern**: `**/.claude/settings.local.json`
- **Scope**: Matches in any directory depth
- **Target**: Only personal settings file (not shared configurations)
- **Impact**: Existing committed files unaffected

## Test Plan

- [x] Pattern correctly excludes `.claude/settings.local.json`
- [x] No other files accidentally excluded
- [x] Existing repository functionality preserved
- [x] Personal settings file no longer tracked by git

🤖 Generated with [Claude Code](https://claude.ai/code)